### PR TITLE
Add tests for RNG seeding and divergence utilities

### DIFF
--- a/axiom-emergence/tests/test_dist.py
+++ b/axiom-emergence/tests/test_dist.py
@@ -1,0 +1,26 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+# Ensure repository root is on sys.path for importing `utils`
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from utils.dist import js_div
+
+torch = pytest.importorskip("torch")
+
+
+def test_js_div_symmetry():
+    p = torch.rand(10)
+    q = torch.rand(10)
+    assert torch.allclose(js_div(p, q), js_div(q, p))
+
+
+def test_js_div_non_negative():
+    p = torch.rand(10)
+    q = torch.rand(10)
+    div = js_div(p, q)
+    assert div >= 0

--- a/axiom-emergence/tests/test_rng.py
+++ b/axiom-emergence/tests/test_rng.py
@@ -1,0 +1,21 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+# Ensure repository root is on sys.path for importing `utils`
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from utils import set_seeds
+
+torch = pytest.importorskip("torch")
+
+
+def test_rng_reproducibility():
+    set_seeds(42)
+    first = torch.rand(3, 3)
+    set_seeds(42)
+    second = torch.rand(3, 3)
+    assert torch.equal(first, second)

--- a/axiom-emergence/tests/test_tasks.py
+++ b/axiom-emergence/tests/test_tasks.py
@@ -1,0 +1,15 @@
+import pytest
+
+
+tasks = pytest.importorskip("tasks")
+
+if not hasattr(tasks, "load_tiny_batch"):
+    pytest.skip("tasks.load_tiny_batch missing", allow_module_level=True)
+
+
+def test_tiny_batch_shapes_and_labels():
+    inputs, labels, num_classes = tasks.load_tiny_batch(batch_size=2)
+    assert inputs.shape[0] == 2
+    assert labels.shape[0] == 2
+    assert labels.min().item() >= 0
+    assert labels.max().item() < num_classes

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,6 @@
+"""Utility package for reproducibility and distance measures."""
+
+from .rng import set_seeds
+from .dist import js_div
+
+__all__ = ["set_seeds", "js_div"]

--- a/utils/dist.py
+++ b/utils/dist.py
@@ -1,0 +1,27 @@
+"""Distance and divergence utilities."""
+
+from __future__ import annotations
+
+try:  # optional dependency
+    import torch
+except Exception:  # pragma: no cover - handled gracefully
+    torch = None  # type: ignore
+
+
+def js_div(p: "torch.Tensor", q: "torch.Tensor") -> "torch.Tensor":
+    """Compute the Jensen-Shannon divergence between two distributions."""
+    if torch is None:  # pragma: no cover - only triggered without torch
+        raise ImportError("PyTorch is required for js_div")
+
+    p = p.float()
+    q = q.float()
+    p = p / p.sum()
+    q = q / q.sum()
+    m = 0.5 * (p + q)
+    eps = 1e-10
+    p_log = torch.log(p + eps)
+    q_log = torch.log(q + eps)
+    m_log = torch.log(m + eps)
+    kl_pm = torch.sum(p * (p_log - m_log))
+    kl_qm = torch.sum(q * (q_log - m_log))
+    return 0.5 * (kl_pm + kl_qm)

--- a/utils/rng.py
+++ b/utils/rng.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 import random
 
-import numpy as np
+try:  # optional dependency
+    import numpy as np
+except Exception:  # pragma: no cover - handled gracefully
+    np = None  # type: ignore
 
 try:  # optional dependency
     import torch
@@ -27,7 +30,8 @@ def set_seeds(seed: int, deterministic: bool = True) -> None:
     """
 
     random.seed(seed)
-    np.random.seed(seed)
+    if np is not None:  # pragma: no branch - numpy optional
+        np.random.seed(seed)
 
     if torch is not None:
         torch.manual_seed(seed)
@@ -36,4 +40,3 @@ def set_seeds(seed: int, deterministic: bool = True) -> None:
         if deterministic:
             torch.backends.cudnn.deterministic = True
             torch.backends.cudnn.benchmark = False
-


### PR DESCRIPTION
## Summary
- add Jensen-Shannon divergence helper
- make RNG seeding resilient to missing numpy
- add tests for RNG reproducibility, JS divergence, and task batch loading

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c60534d00c832c975709940e8716c4