### PR TITLE
Add tiny transformer encoder and fix test imports

### DIFF
--- a/axiom-emergence/models/__init__.py
+++ b/axiom-emergence/models/__init__.py
@@ -1,0 +1,6 @@
+"""Model architectures for Axiom Emergence experiments."""
+
+from .heads import LinearHead
+from .tiny_transformer import TinyTransformer
+
+__all__ = ["LinearHead", "TinyTransformer"]

--- a/axiom-emergence/models/heads.py
+++ b/axiom-emergence/models/heads.py
@@ -1,0 +1,46 @@
+"""Projection heads for downstream tasks.
+
+This module implements a simple linear head used by various models in the
+project. The head is intentionally minimal: it applies a linear projection to
+transform hidden states into logits over the desired output dimension.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+import torch
+from torch import nn
+
+
+class LinearHead(nn.Module):
+    """A minimal linear projection head.
+
+    Parameters
+    ----------
+    d_model:
+        Dimensionality of the incoming hidden states.
+    n_out:
+        Size of the output vocabulary or number of prediction targets.
+    bias:
+        Whether to include a bias term in the projection.
+    """
+
+    def __init__(self, d_model: int, n_out: int, bias: bool = True) -> None:
+        super().__init__()
+        self.proj = nn.Linear(d_model, n_out, bias=bias)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:  # pragma: no cover - trivial
+        """Project hidden states ``x`` to logits."""
+        return self.proj(x)
+
+    # --- parameter targeting -------------------------------------------------
+    def parameter_groups(self) -> list[dict[str, Iterable[nn.Parameter]]]:
+        """Return parameter groups for optimizers or targeted updates.
+
+        The interface mirrors that of the MLP model used elsewhere in the
+        project. Each group is represented as a dictionary with a ``params``
+        entry containing an iterable of the underlying parameters.
+        """
+
+        return [{"params": self.proj.parameters(), "name": "head"}]

--- a/axiom-emergence/models/tiny_transformer.py
+++ b/axiom-emergence/models/tiny_transformer.py
@@ -1,0 +1,100 @@
+"""A minimal Transformer encoder with sinusoidal positional embeddings."""
+
+from __future__ import annotations
+
+import math
+from typing import Iterable
+
+import torch
+from torch import nn
+
+from .heads import LinearHead
+
+
+class TinyTransformer(nn.Module):
+    """A tiny Transformer encoder for experiments and tests.
+
+    Parameters
+    ----------
+    vocab_size:
+        Size of the discrete vocabulary to embed.
+    d_model:
+        Hidden dimension of the model.
+    n_layers:
+        Number of Transformer encoder layers.
+    n_heads:
+        Number of attention heads in each layer.
+    d_ff:
+        Dimensionality of the feedforward network inside each layer.
+    dropout:
+        Dropout probability applied after token/positional embeddings and
+        within the encoder layers.
+    max_len:
+        Maximum sequence length supported by the positional embeddings.
+    n_out:
+        Size of the output projection. Defaults to ``vocab_size``.
+    """
+
+    def __init__(
+        self,
+        vocab_size: int,
+        d_model: int = 128,
+        n_layers: int = 2,
+        n_heads: int = 4,
+        d_ff: int = 256,
+        dropout: float = 0.0,
+        max_len: int = 512,
+        n_out: int | None = None,
+    ) -> None:
+        super().__init__()
+        self.d_model = d_model
+        self.token_embedding = nn.Embedding(vocab_size, d_model)
+        self.dropout = nn.Dropout(dropout)
+        self.register_buffer("positional_encoding", self._build_pos_enc(max_len, d_model), persistent=False)
+
+        encoder_layer = nn.TransformerEncoderLayer(
+            d_model=d_model,
+            nhead=n_heads,
+            dim_feedforward=d_ff,
+            dropout=dropout,
+            batch_first=True,
+        )
+        self.encoder = nn.TransformerEncoder(encoder_layer, num_layers=n_layers)
+        self.head = LinearHead(d_model, n_out or vocab_size)
+
+    # ------------------------------------------------------------------
+    def _build_pos_enc(self, max_len: int, d_model: int) -> torch.Tensor:
+        """Create sinusoidal positional encodings."""
+        pe = torch.zeros(max_len, d_model)
+        position = torch.arange(0, max_len, dtype=torch.float).unsqueeze(1)
+        div_term = torch.exp(
+            torch.arange(0, d_model, 2, dtype=torch.float) * (-math.log(10000.0) / d_model)
+        )
+        pe[:, 0::2] = torch.sin(position * div_term)
+        pe[:, 1::2] = torch.cos(position * div_term)
+        return pe.unsqueeze(0)  # shape (1, max_len, d_model)
+
+    # ------------------------------------------------------------------
+    def forward(self, tokens: torch.Tensor) -> torch.Tensor:
+        """Encode ``tokens`` and return logits from the head."""
+        seq_len = tokens.size(1)
+        x = self.token_embedding(tokens) * math.sqrt(self.d_model)
+        x = x + self.positional_encoding[:, :seq_len]
+        x = self.dropout(x)
+        x = self.encoder(x)
+        return self.head(x)
+
+    # --- parameter targeting -------------------------------------------------
+    def parameter_groups(self) -> list[dict[str, Iterable[nn.Parameter]]]:
+        """Return parameter groups for optimizers or analysis.
+
+        This mirrors the helper provided for the MLP model, exposing separate
+        groups for embeddings, the Transformer encoder, and the output head.
+        """
+
+        groups = [
+            {"params": self.token_embedding.parameters(), "name": "embedding"},
+            {"params": self.encoder.parameters(), "name": "encoder"},
+        ]
+        groups.extend(self.head.parameter_groups())
+        return groups

--- a/axiom-emergence/tests/test_dist.py
+++ b/axiom-emergence/tests/test_dist.py
@@ -4,7 +4,8 @@ from pathlib import Path
 import pytest
 
 # Ensure repository root is on sys.path for importing `utils`
-ROOT = Path(__file__).resolve().parents[2]
+# The tests live in ``repo/tests`` so the project root is one directory up.
+ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 

--- a/axiom-emergence/tests/test_mod_add.py
+++ b/axiom-emergence/tests/test_mod_add.py
@@ -1,7 +1,15 @@
 import os
 import sys
 
-sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
+import pytest
+
+# Add project root (one directory above ``tests``) to ``sys.path`` so that
+# ``tasks`` can be imported when tests are executed from an arbitrary working
+# directory.
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+# Skip the entire module if PyTorch is unavailable.
+torch = pytest.importorskip("torch")
 
 from tasks.mod_add import get_dataloaders
 

--- a/axiom-emergence/tests/test_rng.py
+++ b/axiom-emergence/tests/test_rng.py
@@ -4,7 +4,8 @@ from pathlib import Path
 import pytest
 
 # Ensure repository root is on sys.path for importing `utils`
-ROOT = Path(__file__).resolve().parents[2]
+# The project root is the parent directory of ``tests``.
+ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 

--- a/axiom-emergence/tests/test_tiny_grammar_icl.py
+++ b/axiom-emergence/tests/test_tiny_grammar_icl.py
@@ -1,6 +1,8 @@
 import sys
 from pathlib import Path
-sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+# Add project root (parent of ``tests``) to Python path.
+sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from tasks.tiny_grammar_icl import TinyGrammarICL, VOCAB
 


### PR DESCRIPTION
## Summary
- implement minimal `TinyTransformer` encoder with sinusoidal position encodings
- provide simple `LinearHead` and parameter group helpers for optimizers
- adjust tests to locate project root and skip when PyTorch is unavailable

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c60937a8f8832c919c0f642e278cc0