### PR TITLE
Add cosine warmup scheduler utility

### DIFF
--- a/axiom-emergence/tests/test_sched.py
+++ b/axiom-emergence/tests/test_sched.py
@@ -1,0 +1,30 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+# Ensure repository root is on sys.path for importing packages
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+torch = pytest.importorskip("torch")
+
+from train.sched import cosine_with_warmup
+
+
+def test_cosine_with_warmup_schedule():
+    model = torch.nn.Linear(1, 1)
+    optim = torch.optim.SGD(model.parameters(), lr=1.0)
+
+    sched = cosine_with_warmup(optim, total_steps=10, warmup_frac=0.2)
+
+    lrs = []
+    for _ in range(10):
+        optim.step()
+        sched.step()
+        lrs.append(optim.param_groups[0]["lr"])
+
+    assert lrs[1] > lrs[0]
+    assert max(lrs) == pytest.approx(1.0, rel=1e-6)
+    assert lrs[-1] == pytest.approx(0.0, abs=1e-6)

--- a/axiom-emergence/train/__init__.py
+++ b/axiom-emergence/train/__init__.py
@@ -1,0 +1,1 @@
+# Train package

--- a/axiom-emergence/train/sched.py
+++ b/axiom-emergence/train/sched.py
@@ -1,0 +1,30 @@
+"""Learning rate schedulers for training utilities."""
+
+from __future__ import annotations
+
+from torch.optim import Optimizer
+from torch.optim.lr_scheduler import (
+    CosineAnnealingLR,
+    LinearLR,
+    SequentialLR,
+    LRScheduler,
+)
+
+
+def cosine_with_warmup(
+    optimizer: Optimizer, total_steps: int, warmup_frac: float = 0.02
+) -> LRScheduler:
+    """Cosine annealing schedule with linear warmup."""
+    warmup_steps = max(int(total_steps * warmup_frac), 0)
+    cosine_steps = max(total_steps - warmup_steps, 1)
+
+    cosine_sched = CosineAnnealingLR(optimizer, T_max=cosine_steps)
+
+    if warmup_steps > 0:
+        warmup_sched = LinearLR(
+            optimizer, start_factor=1e-8, end_factor=1.0, total_iters=warmup_steps
+        )
+        return SequentialLR(
+            optimizer, schedulers=[warmup_sched, cosine_sched], milestones=[warmup_steps]
+        )
+    return cosine_sched


### PR DESCRIPTION
## Summary
- add cosine_with_warmup utility combining linear warmup with cosine annealing
- provide minimal train package and associated scheduler test

## Testing
- `PYTHONPATH=axiom-emergence pytest axiom-emergence/tests/test_sched.py::test_cosine_with_warmup_schedule -q`
- `PYTHONPATH=axiom-emergence pytest -q` *(fails: TypeError in utils.dist.js_div)*

------
https://chatgpt.com/codex/tasks/task_e_68c6093e7cbc832c9da5220085255646