### PR TITLE
Add scaling experiment configs

### DIFF
--- a/exp/01_scaling/configs/mod_add.yaml
+++ b/exp/01_scaling/configs/mod_add.yaml
@@ -1,0 +1,17 @@
+# Modular addition experiment configuration
+
+grid:
+  # Number of unique training pairs
+  T: [32, 64, 128]
+  # Modulus for addition task
+  m: [97]
+  # Batch sizes to sweep
+  batch_size: [64, 128]
+  # Random seeds for reproducibility
+  seeds: [0, 1, 2]
+
+recipe:
+  - name: mod_add
+    task: mod_add
+    model: mlp
+    train_steps: 1000

--- a/exp/01_scaling/configs/nat_task.yaml
+++ b/exp/01_scaling/configs/nat_task.yaml
@@ -1,0 +1,13 @@
+# Natural task experiment configuration
+
+grid:
+  # Placeholder parameter for natural tasks
+  dataset: ["nat_task"]
+  # Random seeds for reproducibility
+  seeds: [0, 1, 2]
+
+recipe:
+  - name: nat_task
+    task: nat_task
+    model: transformer
+    train_steps: 1000

--- a/exp/01_scaling/configs/tiny_grammar_icl.yaml
+++ b/exp/01_scaling/configs/tiny_grammar_icl.yaml
@@ -1,0 +1,15 @@
+# Tiny grammar in-context learning experiment configuration
+
+grid:
+  # Maximum length of strings
+  L: [6, 8]
+  # Number of demonstrations per example
+  k: [2]
+  # Random seeds for reproducibility
+  seeds: [0, 1, 2]
+
+recipe:
+  - name: tiny_grammar_icl
+    task: tiny_grammar_icl
+    model: transformer
+    train_steps: 1000


### PR DESCRIPTION
## Summary
- add modular addition, tiny grammar ICL, and natural task config templates
- each config includes parameter grids with seeds and recipe blocks

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c60f4b3610832c9804d2a69a50dc4f