### PR TITLE
Add scaling smoke test target and docs

### DIFF
--- a/axiom-emergence/Makefile
+++ b/axiom-emergence/Makefile
@@ -7,7 +7,7 @@ test:
 	pytest
 
 run-scaling-smoke:
-	AE_SMALL=1 $(PYTHON) exp/scaling/run.py
+	AE_SMALL=1 $(PYTHON) ../exp/01_scaling/run.py
 
 run-scaling:
 	$(PYTHON) exp/scaling/run.py

--- a/axiom-emergence/README.md
+++ b/axiom-emergence/README.md
@@ -1,18 +1,15 @@
 # Axiom Emergence
 
 ## Quickstart
-1. Install dependencies
-   ```bash
-   make setup
-   ```
-2. Run tests
-   ```bash
-   make test
-   ```
-3. Launch a fast smoke test for scaling
-   ```bash
-   make run-scaling-smoke
-   ```
+
+To install dependencies, run the tests, and execute a tiny scaling smoke
+test, run the following commands from this directory:
+
+```bash
+make setup
+make test
+AE_SMALL=1 make run-scaling-smoke
+```
 
 ## Experiments
 Run any of the following to reproduce placeholder experiments:

--- a/exp/01_scaling/run.py
+++ b/exp/01_scaling/run.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+"""Minimal smoke-test script for the scaling experiment.
+
+Running this script creates a single run directory with a placeholder plot so
+that downstream tooling has an artefact to consume.  When the environment
+variable ``AE_SMALL`` is set to ``1`` a deterministic run identifier is used
+so that the output location is predictable for tests.
+"""
+
+import base64
+import os
+from pathlib import Path
+
+# 1x1 white PNG, base64 encoded
+_PNG_BASE64 = (
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/8/AwAI/AL+XqNpAAAAAElFTkSuQmCC="
+)
+
+
+def main() -> None:
+    here = Path(__file__).resolve().parent
+    run_id = "smoke" if os.environ.get("AE_SMALL") == "1" else "run"
+    plot_path = here / "runs" / run_id / "plots" / "collapse_mod_add.png"
+    plot_path.parent.mkdir(parents=True, exist_ok=True)
+    with plot_path.open("wb") as fh:
+        fh.write(base64.b64decode(_PNG_BASE64))
+    print(f"wrote {plot_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `run-scaling-smoke` make target pointing to a minimal `exp/01_scaling/run.py`
- document setup, tests and smoke run sequence in README
- provide tiny script that writes placeholder `collapse_mod_add.png`

## Testing
- `make setup` *(fails: Could not find a version that satisfies the requirement torch==2.1.0)*
- `make test`
- `AE_SMALL=1 make run-scaling-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c61436c80c832ca6921ed6e12a3a3b